### PR TITLE
Osnr/projector hacking

### DIFF
--- a/src/components/ProjectedChessboard.jsx
+++ b/src/components/ProjectedChessboard.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import ProjectedCanvas from './ProjectedCanvas';
 
@@ -42,7 +43,8 @@ function renderChessboard(canvas, rows, cols) {
   return points;
 }
 
-export default function ProjectedChessboard({
+function ProjectedChessboard({
+  dispatch,
   onFullscreen,
   chessboardRows,
   chessboardCols,
@@ -66,6 +68,11 @@ export default function ProjectedChessboard({
     //   ctx.stroke();
     // });
 
+    dispatch({
+      type: 'CALIBRATION_PROJECTOR_POINTS',
+      payload: pointsRelativeToViewport,
+    });
+
     // HACK: trigger this from the fullscreen event somehow
     // (but make sure the new points are passed)
     if (document.fullscreenElement) {
@@ -87,3 +94,5 @@ ProjectedChessboard.propTypes = {
 ProjectedChessboard.defaultProps = {
   onFullscreen: () => {},
 };
+
+export default connect()(ProjectedChessboard);

--- a/src/components/ProjectedChessboard.jsx
+++ b/src/components/ProjectedChessboard.jsx
@@ -53,8 +53,8 @@ function ProjectedChessboard({
     const points = renderChessboard(canvas, chessboardRows, chessboardCols);
 
     const { top, left } = canvas.getBoundingClientRect();
-    // const pointsRelativeToViewport = points.map(([x, y]) => [left + x, top + y]);
-    const pointsRelativeToViewport = points; // FIXME
+    const pointsRelativeToViewport = points.map(([x, y]) => [left + x, top + y]);
+    // const pointsRelativeToViewport = points; // FIXME
     console.log(`Chessboard offset on window is ${left}, ${top}`);
     console.log('Chessboard inner corners:', pointsRelativeToViewport);
 

--- a/src/components/ProjectedToolpath.jsx
+++ b/src/components/ProjectedToolpath.jsx
@@ -120,13 +120,13 @@ function ProjectedToolpath({ toolpath, annotation, project, cameraToCNC, cameraT
       }
     }
 
-    ctx.strokeStyle = '#ffffff';
-    ctx.lineWidth = 4;
-    annotation.forEach(([x, y]) => {
-      ctx.beginPath();
-      ctx.arc(x, y, 10, 0, 2 * Math.PI);
-      ctx.stroke();
-    });
+    // ctx.strokeStyle = '#ffffff';
+    // ctx.lineWidth = 4;
+    // annotation.forEach(([x, y]) => {
+    //   ctx.beginPath();
+    //   ctx.arc(x, y, 10, 0, 2 * Math.PI);
+    //   ctx.stroke();
+    // });
 
     // Draw projection points
     ctx.setTransform(1, 0, 0, 1, 0, 0);
@@ -138,11 +138,14 @@ function ProjectedToolpath({ toolpath, annotation, project, cameraToCNC, cameraT
       ctx.stroke();
     });
 
-    // annotation
-    //   .map(([x, y]) => camToProjector(cameraToProjector, x, y))
-    //   .forEach(([x, y]) => {
-    //     ctx.fillText(`${x.toFixed(0)}, ${y.toFixed(0)}`, x, y); // Adjust text position as needed
-    //   });
+    annotation
+      .map(([x, y]) => camToProjector(cameraToProjector, x, y))
+      .forEach(([x, y]) => {
+        ctx.beginPath();
+        ctx.arc(x, y, 10, 0, 2 * Math.PI);
+        ctx.stroke();
+        ctx.fillText(`${x.toFixed(0)}, ${y.toFixed(0)}`, x, y); // Adjust text position as needed
+      });
   }, [toolpath, annotation, project, cameraToCNC, cameraToProjector]);
 
   return (

--- a/src/components/ProjectorCalibrator.jsx
+++ b/src/components/ProjectorCalibrator.jsx
@@ -78,7 +78,7 @@ function ProjectorCalibrator({ chessboardRows, chessboardCols, projectorPoints, 
           chessboardRows={chessboardRows}
         />
       )}
-      <button onClick={() => { detectChessboard() }}>Detect</button>
+      {!done && <button onClick={() => { detectChessboard() }}>Detect</button>}
       <video ref={videoRef} hidden />
       <canvas ref={canvasRef} hidden />
     </>

--- a/src/reducers/calibration.js
+++ b/src/reducers/calibration.js
@@ -5,6 +5,7 @@ export default function calibrationReducer(state, action) {
         rows: 6,
         cols: 9,
       },
+      projectorPoints: undefined,
       // https://github.com/thsant/3dmcap/blob/b9c5bb16e208c3e37f1ea6d5dc26c9304daf18cc/resources/Logitech-C920.yaml
       camera: {
         fx: 1394.6027293299926,
@@ -51,6 +52,11 @@ export default function calibrationReducer(state, action) {
       return {
         ...state,
         cameraToCNC: action.payload,
+      };
+    case 'CALIBRATION_PROJECTOR_POINTS':
+      return {
+        ...state,
+        projectorPoints: action.payload,
       };
     case 'CALIBRATION_CAM_TO_PROJECTOR':
       if (action.payload.length !== 9) {


### PR DESCRIPTION
Fixes projection mapping by applying the homography directly instead of using the canvas `setTransform` (which only allows affine transforms where a perspective transform is needed).