### PR TITLE
Hide memory usage on browsers that don't support it

### DIFF
--- a/src/components/MemoryUsage.jsx
+++ b/src/components/MemoryUsage.jsx
@@ -1,18 +1,19 @@
 import React, { useEffect } from 'react';
 
 function getMemoryUsage() {
-  return window.performance.memory.usedJSHeapSize / 1024 / 1024;
+  return window.performance.memory?.usedJSHeapSize / 1024 / 1024;
 }
 
 export default function MemoryUsage() {
   const [megabytesUsed, setMegabytesUsed] = React.useState(getMemoryUsage());
 
   useEffect(() => {
+    if (isNaN(megabytesUsed)) return
     const interval = setInterval(() => setMegabytesUsed(getMemoryUsage()), 500);
     return () => clearInterval(interval);
   }, [setMegabytesUsed]);
 
-  return (
+  return isNaN(megabytesUsed) ? <></> : (
     <span>
       {`JS Heap: ${megabytesUsed.toFixed(2)} MB`}
     </span>


### PR DESCRIPTION
My browser doesn't have window.performance.memory, so there's a hard crash when rendering. This should work around that.